### PR TITLE
Batch tt

### DIFF
--- a/t3f/ops_test.py
+++ b/t3f/ops_test.py
@@ -398,5 +398,19 @@ class TTTensorBatchTest(tf.test.TestCase):
         actual = ops.full(tf_tens)
         self.assertAllClose(desired, actual.eval())
 
+  def testFullTensor3d(self):
+    np.random.seed(1)
+    for rank_1 in [1, 2]:
+      a = np.random.rand(3, 10, rank_1).astype(np.float32)
+      b = np.random.rand(3, rank_1, 9, 3).astype(np.float32)
+      c = np.random.rand(3, 3, 8).astype(np.float32)
+      tt_cores = (a.reshape(3, 1, 10, rank_1), b, c.reshape((3, 3, 8, 1)))
+      # Basically do full by hand.
+      desired = np.einsum('oia,oajb,obk->oijk', a, b, c)
+      with self.test_session():
+        tf_tens = TensorTrainBatch(tt_cores)
+        actual = ops.full(tf_tens)
+        self.assertAllClose(desired, actual.eval())
+
 if __name__ == "__main__":
   tf.test.main()

--- a/t3f/ops_test.py
+++ b/t3f/ops_test.py
@@ -412,5 +412,24 @@ class TTTensorBatchTest(tf.test.TestCase):
         actual = ops.full(tf_tens)
         self.assertAllClose(desired, actual.eval())
 
+  def testFlatInnerTTTensbyTTTensSameBatchSize(self):
+    # Inner product between two batch TT-tensors of the same batch_size.
+    shape_list = ((2, 2),
+                  (2, 3, 4))
+    rank_list = (1, 2)
+    with self.test_session() as sess:
+      for shape in shape_list:
+        for rank in rank_list:
+          tt_1 = initializers.random_tensor_batch(shape, tt_rank=rank,
+                                                  batch_size=2)
+          tt_2 = initializers.random_tensor_batch(shape, tt_rank=rank,
+                                                  batch_size=2)
+          res_actual = ops.tt_tt_flat_inner(tt_1, tt_2)
+          tt_1_full = tf.reshape(ops.full(tt_1), (1, -1))
+          tt_2_full = tf.reshape(ops.full(tt_2), (-1, 1))
+          res_desired = tf.matmul(tt_1_full, tt_2_full)
+          res_actual_val, res_desired_val = sess.run([res_actual, res_desired])
+          self.assertAllClose(res_actual_val, res_desired_val, rtol=1e-5)
+
 if __name__ == "__main__":
   tf.test.main()

--- a/t3f/shapes.py
+++ b/t3f/shapes.py
@@ -61,10 +61,13 @@ def raw_shape(tt):
   num_dims = tt.ndims()
   num_tensor_axis = len(tt.get_raw_shape())
   final_raw_shape = []
+  # TODO: ugly.
+  from tensor_train import TensorTrain
+  axes_shift = 1 if isinstance(tt, TensorTrain) else 2
   for ax in range(num_tensor_axis):
     curr_raw_shape = []
     for core_idx in range(num_dims):
-      curr_raw_shape.append(tf.shape(tt.tt_cores[core_idx])[ax + 1])
+      curr_raw_shape.append(tf.shape(tt.tt_cores[core_idx])[ax + axes_shift])
     final_raw_shape.append(tf.stack(curr_raw_shape, axis=0))
   return tf.stack(final_raw_shape, axis=0)
 

--- a/t3f/shapes.py
+++ b/t3f/shapes.py
@@ -72,6 +72,13 @@ def raw_shape(tt):
   return tf.stack(final_raw_shape, axis=0)
 
 
+def batch_size(tt):
+  """Return the number of elements in a TensorTrainBatch.
+
+  Return 0-D integer tensor."""
+  return tf.shape(tt.tt_cores[0])[0]
+
+
 def lazy_tt_ranks(tt):
   """Returns static TT-ranks of a TensorTrain if defined, and dynamic otherwise.
 
@@ -134,6 +141,23 @@ def lazy_raw_shape(tt):
     return np.array([s.as_list() for s in tt.get_raw_shape()])
   else:
     return raw_shape(tt)
+
+
+def lazy_batch_size(tt):
+  """Return static batch_size if available and dynamic otherwise.
+
+  Args:
+    tt: `TensorTrainBatch` object.
+
+  Returns:
+    A number or a 0-D `tf.Tensor`
+
+  Raises:
+    ValueError if got `TensorTrain` which doesn't have batch_size as input."""
+  if tt.batch_size is not None:
+    return tt.batch_size
+  else:
+    return batch_size(tt)
 
 
 def clean_raw_shape(shape):

--- a/t3f/shapes.py
+++ b/t3f/shapes.py
@@ -81,7 +81,9 @@ def batch_size(tt):
     ValueError if got `TensorTrain` which doesn't have batch_size as input."""
   if not hasattr(tt, 'batch_size'):
     raise ValueError('batch size is not available for a TensorTrain object.')
-  return tf.shape(tt.tt_cores[0])[0]
+  first_core = tt.tt_cores[0]
+  # The first dimension of any TT-core in TensorTrainBatch is the batch size.
+  return tf.shape(first_core)[0]
 
 
 def lazy_tt_ranks(tt):

--- a/t3f/shapes.py
+++ b/t3f/shapes.py
@@ -75,7 +75,12 @@ def raw_shape(tt):
 def batch_size(tt):
   """Return the number of elements in a TensorTrainBatch.
 
-  Return 0-D integer tensor."""
+  Return 0-D integer tensor.
+
+  Raises:
+    ValueError if got `TensorTrain` which doesn't have batch_size as input."""
+  if not hasattr(tt, 'batch_size'):
+    raise ValueError('batch size is not available for a TensorTrain object.')
   return tf.shape(tt.tt_cores[0])[0]
 
 
@@ -154,6 +159,8 @@ def lazy_batch_size(tt):
 
   Raises:
     ValueError if got `TensorTrain` which doesn't have batch_size as input."""
+  if not hasattr(tt, 'batch_size'):
+    raise ValueError('batch size is not available for a TensorTrain object.')
   if tt.batch_size is not None:
     return tt.batch_size
   else:

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -122,12 +122,7 @@ class TensorTrain(TensorTrainBase):
           if remainder is not None:
             # Add reminder from the previous collapsed cores to the current
             # core.
-            # TODO: is it bad to use as_list? E.g. if we dont now the ranks
-            # on the graph construction stage.
-            old_shape = sliced_core.get_shape().as_list()
-            sliced_core = tf.reshape(sliced_core, (old_shape[0], -1))
-            sliced_core = tf.matmul(remainder, sliced_core)
-            sliced_core = tf.reshape(sliced_core, (-1, old_shape[1], old_shape[2]))
+            sliced_core = tf.einsum('ab,bid->aid', remainder, sliced_core)
             remainder = None
           new_tt_cores.append(sliced_core)
 

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -1,11 +1,11 @@
 import numpy as np
 import tensorflow as tf
 
+from tensor_train_base import TensorTrainBase
 import shapes
 
 
-# TODO: check the methods of _TensorLike
-class TensorTrain(object):
+class TensorTrain(TensorTrainBase):
   """Represents a Tensor Train object (a TT-tensor or TT-matrix).
 
   t3f represents a Tensor Train object as a tuple of TT-cores.
@@ -68,31 +68,6 @@ class TensorTrain(object):
     if self._tt_ranks is None:
       self._tt_ranks = _infer_tt_ranks(self._tt_cores)
 
-  def get_raw_shape(self):
-    """Get tuple of `TensorShapes` representing the shapes of the underlying TT-tensor.
-
-    Tuple contains one `TensorShape` for TT-tensor and 2 `TensorShapes` for
-    TT-matrix
-
-    Returns:
-      A tuple of `TensorShape` objects.
-    """
-    return self._raw_shape
-
-  def get_shape(self):
-    """Get the `TensorShape` representing the shape of the dense tensor.
-
-    Returns:
-      A `TensorShape` object.
-    """
-    raw_shape = self.get_raw_shape()
-    if self.is_tt_matrix():
-      m = np.prod(raw_shape[0].as_list())
-      n = np.prod(raw_shape[1].as_list())
-      return tf.TensorShape((m, n))
-    else:
-      return raw_shape[0]
-
   @property
   def tt_cores(self):
     """A tuple of TT-cores.
@@ -101,29 +76,6 @@ class TensorTrain(object):
       A tuple of 3d or 4d tensors shape `[r_k-1, n_k, r_k]`.
     """
     return self._tt_cores
-
-  @property
-  def dtype(self):
-    """The `DType` of elements in this tensor."""
-    # TODO: where is this created?
-    return self.tt_cores[0].dtype
-
-  @property
-  def name(self):
-    """The name of the TensorTrain.
-
-    Returns:
-      String, the scope in which the TT-cores are defined.
-    """
-    core_name = self.tt_cores[0].name
-    idx = core_name.rfind('/')
-    return core_name[:idx]
-
-  @property
-  def graph(self):
-    """The `Graph` that contains the tt_cores tensors."""
-    # TODO: check in init that the other cores are from the same graph.
-    return self.tt_cores[0].graph
 
   def __str__(self):
     """A string describing the TensorTrain object, its TT-rank and shape."""
@@ -138,32 +90,6 @@ class TensorTrain(object):
                                                tt_ranks)
     else:
       return "A Tensor Train of shape %s, TT-ranks: %s" % (shape, tt_ranks)
-
-  def ndims(self):
-    """Get the number of dimensions of the underlying TT-tensor.
-
-    Returns:
-      A number.
-    """
-    return len(self.tt_cores)
-
-  def get_tt_ranks(self):
-    """Get the TT-ranks in an array of size `num_dims`+1.
-
-    The first and the last TT-rank are guarantied to be 1.
-
-    Returns:
-      TensorShape of size `num_dims`+1.
-    """
-    return self._tt_ranks
-
-  def num_tensor_axes(self):
-    """Number of modes per core. 1 for TT-tensors and 2 for TT-matrices."""
-    return len(self.get_raw_shape())
-
-  def is_tt_matrix(self):
-    """Returns True if the TensorTrain object represents a TT-matrix."""
-    return self.num_tensor_axes() == 2
 
   def __getitem__(self, slice_spec):
     """Basic indexing, returns a `TensorTrain` containing the specified region.
@@ -203,53 +129,6 @@ class TensorTrain(object):
       new_tt_cores[-1] = tf.reshape(new_tt_cores[-1], (old_shape[0], old_shape[1], 1))
       remainder = None
     return TensorTrain(new_tt_cores)
-
-  def eval(self, feed_dict=None, session=None):
-    """Evaluates this sparse tensor in a `Session`.
-
-    Calling this method will execute all preceding operations that
-    produce the inputs needed for the operation that produces this
-    tensor.
-    *N.B.* Before invoking `SparseTensor.eval()`, its graph must have been
-    launched in a session, and either a default session must be
-    available, or `session` must be specified explicitly.
-
-    Args:
-      feed_dict: A dictionary that maps `Tensor` objects to feed values.
-        See [`Session.run()`](../../api_docs/python/client.md#Session.run) for a
-        description of the valid feed values.
-      session: (Optional.) The `Session` to be used to evaluate this sparse
-        tensor. If none, the default session will be used.
-    """
-    # TODO: what to return, None?
-    if session is None:
-      session = tf.get_default_session()
-    session.run(self.tt_cores)
-
-  # TODO: do we need this?
-  # @staticmethod
-  # def _override_operator(operator, func):
-  #   _override_helper(SparseTensor, operator, func)
-
-  def __add__(self, other):
-    """Returns a TensorTrain corresponding to element-wise sum tt_a + tt_b.
-
-    Just calls t3f.add, see its documentation for details.
-    """
-    # TODO: ugly.
-    # We can't import ops in the beginning since it creates cyclic dependencies.
-    import ops
-    return ops.add(self, other)
-
-  def __mul__(self, other):
-    """Returns a TensorTrain corresponding to element-wise product tt_a * tt_b.
-
-    Just calls t3f.multiply, see its documentation for details.
-    """
-    # TODO: ugly.
-    # We can't import ops in the beginning since it creates cyclic dependencies.
-    import ops
-    return ops.multiply(self, other)
 
 
 def _are_tt_cores_valid(tt_cores, shape, tt_ranks):

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -60,9 +60,9 @@ class TensorTrain(object):
                        'with the provided shape.')
 
     self._tt_cores = tuple(tt_cores)
-    self._shape = shapes.clean_raw_shape(shape)
-    if self._shape is None:
-      self._shape = _infer_raw_shape(self._tt_cores)
+    self._raw_shape = shapes.clean_raw_shape(shape)
+    if self._raw_shape is None:
+      self._raw_shape = _infer_raw_shape(self._tt_cores)
     self._tt_ranks = None if tt_ranks is None else tf.TensorShape(tt_ranks)
     if self._tt_ranks is None:
       self._tt_ranks = _infer_tt_ranks(self._tt_cores)
@@ -76,7 +76,7 @@ class TensorTrain(object):
     Returns:
       A tuple of `TensorShape` objects.
     """
-    return self._shape
+    return self._raw_shape
 
   def get_shape(self):
     """Get the `TensorShape` representing the shape of the dense tensor.
@@ -162,8 +162,8 @@ class TensorTrain(object):
     Returns:
       bool
     """
-    if self._shape is not None:
-      return len(self._shape) == 2
+    if self._raw_shape is not None:
+      return len(self._raw_shape) == 2
     return len(self.tt_cores[0].get_shape().as_list()) == 4
 
   def __getitem__(self, slice_spec):

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -130,6 +130,7 @@ class TensorTrain(TensorTrainBase):
       # The reminder obtained from collapsing the last cores.
       new_tt_cores[-1] = tf.einsum('aib,bd->aid', new_tt_cores[-1], remainder)
       remainder = None
+    # TODO: infer the output ranks and shape.
     return TensorTrain(new_tt_cores)
 
 

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 from tensor_train_base import TensorTrainBase
@@ -21,6 +20,7 @@ class TensorTrain(TensorTrainBase):
   @@get_tt_ranks
   @@num_tensor_axes
   @@is_tt_matrix
+  @@is_variable
   @@eval
   """
 
@@ -56,9 +56,9 @@ class TensorTrain(TensorTrainBase):
           tt_cores[i] = tf.convert_to_tensor(tt_cores[i], name=name)
 
     if not _are_tt_cores_valid(tt_cores, shape, tt_ranks):
-      raise ValueError('the tt_cores provided to TensorTrain constructor are '
+      raise ValueError('The tt_cores provided to TensorTrain constructor are '
                        'not valid, have different dtypes, or are inconsistent '
-                       'with the provided shape.')
+                       'with the provided shape or TT-ranks.')
 
     self._tt_cores = tuple(tt_cores)
     self._raw_shape = shapes.clean_raw_shape(shape)
@@ -73,23 +73,27 @@ class TensorTrain(TensorTrainBase):
     """A tuple of TT-cores.
 
     Returns:
-      A tuple of 3d or 4d tensors shape `[r_k-1, n_k, r_k]`.
+      A tuple of 3d or 4d tensors shape
+        `[r_k-1, n_k, r_k]`
+      or
+        `[r_k-1, n_k, m_k, r_k]`
     """
     return self._tt_cores
 
   def __str__(self):
-    """A string describing the TensorTrain object, its TT-rank and shape."""
-    # TODO: tensors vs variables.
+    """A string describing the TensorTrain object, its TT-rank, and shape."""
     shape = self.get_shape()
     tt_ranks = self.get_tt_ranks()
+    variable_str = ' variable' if self.is_variable() else ''
     if self.is_tt_matrix():
       raw_shape = self.get_raw_shape()
-      return "A Tensor Train Matrix of size %d x %d, underlying tensor " \
-             "shape: %s x %s, TT-ranks: %s" % (shape[0], shape[1],
+      return "A TT-Matrix%s of size %d x %d, underlying tensor " \
+             "shape: %s x %s, TT-ranks: %s" % (variable_str, shape[0], shape[1],
                                                raw_shape[0], raw_shape[1],
                                                tt_ranks)
     else:
-      return "A Tensor Train of shape %s, TT-ranks: %s" % (shape, tt_ranks)
+      return "A Tensor Train%s of shape %s, TT-ranks: %s" % (variable_str,
+                                                              shape, tt_ranks)
 
   def __getitem__(self, slice_spec):
     """Basic indexing, returns a `TensorTrain` containing the specified region.

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -18,7 +18,6 @@ class TensorTrain(TensorTrainBase):
   @@graph
   @@ndims
   @@get_tt_ranks
-  @@num_tensor_axes
   @@is_tt_matrix
   @@is_variable
   @@eval

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -128,10 +128,7 @@ class TensorTrain(TensorTrainBase):
 
     if remainder is not None:
       # The reminder obtained from collapsing the last cores.
-      old_shape = new_tt_cores[-1].get_shape().as_list()
-      new_tt_cores[-1] = tf.reshape(new_tt_cores[-1], (-1, old_shape[-1]))
-      new_tt_cores[-1] = tf.matmul(new_tt_cores[-1], remainder)
-      new_tt_cores[-1] = tf.reshape(new_tt_cores[-1], (old_shape[0], old_shape[1], 1))
+      new_tt_cores[-1] = tf.einsum('aib,bd->aid', new_tt_cores[-1], remainder)
       remainder = None
     return TensorTrain(new_tt_cores)
 

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -96,6 +96,13 @@ class TensorTrain(TensorTrainBase):
 
   def __getitem__(self, slice_spec):
     """Basic indexing, returns a `TensorTrain` containing the specified region.
+
+    Examples:
+      >>> a = t3f.random_tensor((2, 3, 4))
+      >>> a[1, :, :]
+      is a 2D TensorTrain 3 x 4.
+      >>> a[1:2, :, :]
+      is a 3D TensorTrain 1 x 3 x 4
     """
     new_tt_cores = []
     remainder = None

--- a/t3f/tensor_train.py
+++ b/t3f/tensor_train.py
@@ -19,6 +19,7 @@ class TensorTrain(object):
   @@graph
   @@ndims
   @@get_tt_ranks
+  @@num_tensor_axes
   @@is_tt_matrix
   @@eval
   """
@@ -156,15 +157,13 @@ class TensorTrain(object):
     """
     return self._tt_ranks
 
-  def is_tt_matrix(self):
-    """Returns True if the TensorTrain object represents a TT-matrix.
+  def num_tensor_axes(self):
+    """Number of modes per core. 1 for TT-tensors and 2 for TT-matrices."""
+    return len(self.get_raw_shape())
 
-    Returns:
-      bool
-    """
-    if self._raw_shape is not None:
-      return len(self._raw_shape) == 2
-    return len(self.tt_cores[0].get_shape().as_list()) == 4
+  def is_tt_matrix(self):
+    """Returns True if the TensorTrain object represents a TT-matrix."""
+    return self.num_tensor_axes() == 2
 
   def __getitem__(self, slice_spec):
     """Basic indexing, returns a `TensorTrain` containing the specified region.

--- a/t3f/tensor_train_base.py
+++ b/t3f/tensor_train_base.py
@@ -22,7 +22,6 @@ class TensorTrainBase(object):
 
   def __init__(self, tt_cores):
     """Creates a `TensorTrainBase`."""
-    self._tt_cores = tt_cores
     pass
 
   def get_raw_shape(self):
@@ -44,6 +43,7 @@ class TensorTrainBase(object):
     """
     raw_shape = self.get_raw_shape()
     if self.is_tt_matrix():
+      # TODO: as list is not available if shape is partly known.
       m = np.prod(raw_shape[0].as_list())
       n = np.prod(raw_shape[1].as_list())
       return tf.TensorShape((m, n))

--- a/t3f/tensor_train_base.py
+++ b/t3f/tensor_train_base.py
@@ -1,0 +1,159 @@
+import numpy as np
+import tensorflow as tf
+
+
+# TODO: check the methods of _TensorLike
+class TensorTrainBase(object):
+  """An abstract class that represents a collection of Tensor Train cores.
+  ```
+  @@__init__
+  @@get_raw_shape
+  @@get_shape
+  @@tt_cores
+  @@dtype
+  @@name
+  @@graph
+  @@ndims
+  @@get_tt_ranks
+  @@num_tensor_axes
+  @@is_tt_matrix
+  @@eval
+  """
+
+  def __init__(self, tt_cores):
+    """Creates a `TensorTrainBase`."""
+    self._tt_cores = tt_cores
+    pass
+
+  def get_raw_shape(self):
+    """Get tuple of `TensorShapes` representing the shapes of the underlying TT-tensor.
+
+    Tuple contains one `TensorShape` for TT-tensor and 2 `TensorShapes` for
+    TT-matrix
+
+    Returns:
+      A tuple of `TensorShape` objects.
+    """
+    return self._raw_shape
+
+  def get_shape(self):
+    """Get the `TensorShape` representing the shape of the dense tensor.
+
+    Returns:
+      A `TensorShape` object.
+    """
+    raw_shape = self.get_raw_shape()
+    if self.is_tt_matrix():
+      m = np.prod(raw_shape[0].as_list())
+      n = np.prod(raw_shape[1].as_list())
+      return tf.TensorShape((m, n))
+    else:
+      return raw_shape[0]
+
+  @property
+  def tt_cores(self):
+    """A tuple of TT-cores."""
+    return self._tt_cores
+
+  @property
+  def dtype(self):
+    """The `DType` of elements in this tensor."""
+    # TODO: where is this created?
+    return self.tt_cores[0].dtype
+
+  @property
+  def name(self):
+    """The name of the TensorTrain.
+
+    Returns:
+      String, the scope in which the TT-cores are defined.
+    """
+    core_name = self.tt_cores[0].name
+    idx = core_name.rfind('/')
+    return core_name[:idx]
+
+  @property
+  def graph(self):
+    """The `Graph` that contains the tt_cores tensors."""
+    # TODO: check in init that the other cores are from the same graph.
+    return self.tt_cores[0].graph
+
+  def __str__(self):
+    """A string describing the TensorTrain object, its TT-rank and shape."""
+    return NotImplementedError
+
+  def ndims(self):
+    """Get the number of dimensions of the underlying TT-tensor.
+
+    Returns:
+      A number.
+    """
+    return len(self.tt_cores)
+
+  def get_tt_ranks(self):
+    """Get the TT-ranks in an array of size `num_dims`+1.
+
+    The first and the last TT-rank are guarantied to be 1.
+
+    Returns:
+      TensorShape of size `num_dims`+1.
+    """
+    return self._tt_ranks
+
+  def num_tensor_axes(self):
+    """Number of modes per core. 1 for TT-tensors and 2 for TT-matrices."""
+    return len(self.get_raw_shape())
+
+  def is_tt_matrix(self):
+    """Returns True if the TensorTrain object represents a TT-matrix."""
+    return self.num_tensor_axes() == 2
+
+  def eval(self, feed_dict=None, session=None):
+    """Evaluates this sparse tensor in a `Session`.
+
+    Calling this method will execute all preceding operations that
+    produce the inputs needed for the operation that produces this
+    tensor.
+    *N.B.* Before invoking `SparseTensor.eval()`, its graph must have been
+    launched in a session, and either a default session must be
+    available, or `session` must be specified explicitly.
+
+    Args:
+      feed_dict: A dictionary that maps `Tensor` objects to feed values.
+        See [`Session.run()`](../../api_docs/python/client.md#Session.run) for a
+        description of the valid feed values.
+      session: (Optional.) The `Session` to be used to evaluate this sparse
+        tensor. If none, the default session will be used.
+    """
+    # TODO: implement feed_dict
+    if session is None:
+      session = tf.get_default_session()
+    session.run(self.tt_cores)
+
+  # TODO: do we need this?
+  # @staticmethod
+  # def _override_operator(operator, func):
+  #   _override_helper(SparseTensor, operator, func)
+
+  def __add__(self, other):
+    """Returns a TensorTrain corresponding to element-wise sum tt_a + tt_b.
+
+    Supports broadcasting (e.g. you can add TensorTrainBatch and TensorTrain).
+    Just calls t3f.add, see its documentation for details.
+    """
+    # TODO: ugly.
+    # We can't import ops in the beginning since it creates cyclic dependencies.
+    import ops
+    return ops.add(self, other)
+
+  def __mul__(self, other):
+    """Returns a TensorTrain corresponding to element-wise product tt_a * tt_b.
+
+    Supports broadcasting (e.g. you can multiply TensorTrainBatch and
+    TensorTrain).
+    Just calls t3f.multiply, see its documentation for details.
+    """
+    # TODO: ugly.
+    # We can't import ops in the beginning since it creates cyclic dependencies.
+    import ops
+    return ops.multiply(self, other)

--- a/t3f/tensor_train_base.py
+++ b/t3f/tensor_train_base.py
@@ -15,7 +15,6 @@ class TensorTrainBase(object):
   @@graph
   @@ndims
   @@get_tt_ranks
-  @@num_tensor_axes
   @@is_tt_matrix
   @@is_variable
   @@eval
@@ -101,13 +100,9 @@ class TensorTrainBase(object):
     """
     return self._tt_ranks
 
-  def num_tensor_axes(self):
-    """Number of modes per core. 1 for TT-tensors and 2 for TT-matrices."""
-    return len(self.get_raw_shape())
-
   def is_tt_matrix(self):
     """Returns True if the TensorTrain object represents a TT-matrix."""
-    return self.num_tensor_axes() == 2
+    return len(self.get_raw_shape()) == 2
 
   def is_variable(self):
     """True if the TensorTrain object is a variable (e.g. is trainable)."""

--- a/t3f/tensor_train_base.py
+++ b/t3f/tensor_train_base.py
@@ -17,6 +17,7 @@ class TensorTrainBase(object):
   @@get_tt_ranks
   @@num_tensor_axes
   @@is_tt_matrix
+  @@is_variable
   @@eval
   """
 
@@ -107,6 +108,10 @@ class TensorTrainBase(object):
   def is_tt_matrix(self):
     """Returns True if the TensorTrain object represents a TT-matrix."""
     return self.num_tensor_axes() == 2
+
+  def is_variable(self):
+    """True if the TensorTrain object is a variable (e.g. is trainable)."""
+    return isinstance(self.tt_cores[0], tf.Variable)
 
   def eval(self, feed_dict=None, session=None):
     """Evaluates this sparse tensor in a `Session`.

--- a/t3f/tensor_train_batch.py
+++ b/t3f/tensor_train_batch.py
@@ -1,4 +1,5 @@
 import numbers
+import numpy as np
 import tensorflow as tf
 
 from tensor_train_base import TensorTrainBase
@@ -77,6 +78,17 @@ class TensorTrainBatch(TensorTrainBase):
     if self._tt_ranks is None:
       self._tt_ranks = _infer_batch_tt_ranks(self._tt_cores)
 
+  def get_shape(self):
+    """Get the `TensorShape` representing the shape of the dense tensor.
+
+    The first dimension is the batch_size.
+
+    Returns:
+      A `TensorShape` object.
+    """
+    shape = TensorTrainBase.get_shape(self)
+    return tf.TensorShape(np.hstack((self.batch_size, shape)))
+
   @property
   def tt_cores(self):
     """A tuple of TT-cores.
@@ -88,6 +100,11 @@ class TensorTrainBatch(TensorTrainBase):
         `[batch_size, r_k-1, n_k, m_k, r_k]`
     """
     return self._tt_cores
+
+  @property
+  def batch_size(self):
+    """The number of elements or None if not known."""
+    return self._batch_size
 
   def __str__(self):
     """A string describing the TensorTrainBatch, its TT-rank and shape."""

--- a/t3f/tensor_train_batch.py
+++ b/t3f/tensor_train_batch.py
@@ -1,0 +1,275 @@
+import numbers
+import tensorflow as tf
+
+from tensor_train_base import TensorTrainBase
+from tensor_train import TensorTrain
+import shapes
+
+
+class TensorTrainBatch(TensorTrainBase):
+  """Represents a batch of Tensor Train objects (TT-tensors or TT-matrices).
+
+  t3f represents a Tensor Train object as a tuple of TT-cores.
+  ```
+  @@__init__
+  @@get_raw_shape
+  @@get_shape
+  @@tt_cores
+  @@dtype
+  @@name
+  @@graph
+  @@ndims
+  @@get_tt_ranks
+  @@is_tt_matrix
+  @@is_variable
+  @@eval
+  """
+
+  def __init__(self, tt_cores, shape=None, tt_ranks=None, batch_size=None,
+               convert_to_tensors=True):
+    """Creates a `TensorTrain`.
+
+    Args:
+      tt_cores: A tuple of 3d or 4d tensor-like objects of shape
+        `[r_k-1, n_k, r_k]`.
+        Tensor-like can be numpy array, tf.Tensor, of tf.Variable
+      batch_size: number of elements in the batch. If None, tries to infer from
+        the TT-cores (not always possible even if it should be, e.g. if ranks
+        are unknown, than the whole shape of a core can be unknown).
+      shape: Shape of the underlying tensor. If None, tries to infer from the
+        TT-cores.
+      tt_ranks: a TensorShape of length d+1 (d is the dimensionality of
+        the underlying tensor). The first and the last ranks are assumed to
+        equal to 1. If None, tries to infer the ranks from the cores.
+      convert_to_tensors: bool, if True than convert each element of the
+        tt_cores tuple into a tf.Tensor (e.g. to initialize from np.array)
+
+    Returns:
+      A `TensorTrainBatch`.
+
+    Raises:
+      ValueError if the provided TT-cores are not valid or inconsistent with
+        the provided shape.
+    """
+    tt_cores = list(tt_cores)
+    if convert_to_tensors:
+      # TODO: what does this namescope do?
+      with tf.name_scope("TensorTrainBatch", tt_cores):
+        for i in range(len(tt_cores)):
+          name = "core%d" % i
+          tt_cores[i] = tf.convert_to_tensor(tt_cores[i], name=name)
+
+    if not _are_batch_tt_cores_valid(tt_cores, shape, tt_ranks, batch_size):
+      raise ValueError('The tt_cores provided to TensorTrainBatch constructor '
+                       'are not valid, have different dtypes, or are '
+                       'inconsistent with the provided batch_size, shape, or '
+                       'TT-ranks.')
+
+    self._tt_cores = tuple(tt_cores)
+    if batch_size is None:
+      self._batch_size = tt_cores[0].get_shape()[0].value
+    else:
+      self._batch_size = batch_size
+    self._raw_shape = shapes.clean_raw_shape(shape)
+    if self._raw_shape is None:
+      self._raw_shape = _infer_batch_raw_shape(self._tt_cores)
+    self._tt_ranks = None if tt_ranks is None else tf.TensorShape(tt_ranks)
+    if self._tt_ranks is None:
+      self._tt_ranks = _infer_batch_tt_ranks(self._tt_cores)
+
+  @property
+  def tt_cores(self):
+    """A tuple of TT-cores.
+
+    Returns:
+      A tuple of 4d or 5d tensors shape
+        `[batch_size, r_k-1, n_k, r_k]`
+      or
+        `[batch_size, r_k-1, n_k, m_k, r_k]`
+    """
+    return self._tt_cores
+
+  def __str__(self):
+    """A string describing the TensorTrainBatch, its TT-rank and shape."""
+    shape = self.get_shape()
+    tt_ranks = self.get_tt_ranks()
+
+    if self.is_tt_matrix():
+      raw_shape = self.get_raw_shape()
+      type_str = 'TT-matrix variables' if self.is_variable() else 'TT-matrices'
+      return "A %d element batch of %s of size %d x %d, underlying tensor " \
+             "shape: %s x %s, TT-ranks: %s" % (self.batch_size, type_str,
+                                               shape[0], shape[1],
+                                               raw_shape[0], raw_shape[1],
+                                               tt_ranks)
+    else:
+      if self.is_variable():
+        type_str = 'Tensor Train variables'
+      else:
+        type_str = 'Tensor Trains'
+      return "A %d element batch of %s of shape %s, TT-ranks: %s" % \
+             (self.batch_size, type_str, shape, tt_ranks)
+
+  def __getitem__(self, slice_spec):
+    """Basic indexing, returns a `TensorTrainBatch` with the specified region.
+
+    Examples:
+      >>> a = t3f.random_tensor_batch((2, 3, 4), batch_size=5)
+      >>> a[1:3, :, :, :]
+      is a 3D TensorTrainBatch 2 x 3 x 4 with batch_size = 2.
+      >>> a[1:3]
+      the same as above, a 3D TensorTrainBatch 2 x 3 x 4 with batch_size = 2.
+      >>> a[1, :, :, :]
+      is a 3D TensorTrain 2 x 3 x 4.
+      >>> a[1]
+      the same as above, a 3D TensorTrain 2 x 3 x 4.
+      >>> a[1:3, :, 1, :]
+      is a 2D TensorTrainBatch 2 x 4 with batch_size = 2.
+      >>> a[1, :, 1, :]
+      is a 2D TensorTrain 2 x 4.
+    """
+    new_tt_cores = []
+    # This object index is specified exactly and we want to collapse the
+    # batch_size axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
+    do_collapse_batch_dim = isinstance(slice_spec[0], numbers.Number)
+
+    if len(slice_spec) == 1:
+      # Indexing only for the batch_size axis, e.g. a[1:3].
+      slice_spec = slice_spec[0]
+      for core_idx in range(self.ndims()):
+        curr_core = self.tt_cores[core_idx]
+        if self.is_tt_matrix():
+          new_tt_cores.append(curr_core[slice_spec, :, :, :, :])
+        else:
+          new_tt_cores.append(curr_core[slice_spec, :, :, :])
+      if do_collapse_batch_dim:
+        # This index is specified exactly and we want to collapse the batch_size
+        # axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
+        return TensorTrain(new_tt_cores, self.get_raw_shape(),
+                           self.get_tt_ranks())
+      else:
+        batch_size = new_tt_cores[0].get_shape()[0]
+        return TensorTrainBatch(new_tt_cores, batch_size, self.get_raw_shape(),
+                                self.get_tt_ranks())
+    elif len(slice_spec) == self.ndims() + 1:
+      remainder = None
+      for core_idx in range(self.ndims()):
+        curr_core = self.tt_cores[core_idx]
+        if self.is_tt_matrix():
+          raise NotImplementedError
+        else:
+          sliced_core = curr_core[slice_spec[0], :, slice_spec[core_idx + 1], :]
+          if len(curr_core.get_shape()) != len(sliced_core.get_shape()):
+            # This index is specified exactly and we want to collapse this axis.
+            if remainder is None:
+              remainder = sliced_core
+            else:
+              if do_collapse_batch_dim:
+                remainder = tf.einsum('ab,bd->ad', remainder, sliced_core)
+              else:
+                remainder = tf.einsum('oab,obd->oad', remainder, sliced_core)
+          else:
+            if remainder is not None:
+              # Add reminder from the previous collapsed cores to the current
+              # core.
+              if do_collapse_batch_dim:
+                sliced_core = tf.einsum('ab,bid->aid', remainder, sliced_core)
+              else:
+                sliced_core = tf.einsum('oab,obid->oaid', remainder,
+                                        sliced_core)
+              remainder = None
+            new_tt_cores.append(sliced_core)
+
+      if remainder is not None:
+        # The reminder obtained from collapsing the last cores.
+        if do_collapse_batch_dim:
+          new_tt_cores[-1] = tf.einsum('aib,bd->aid', new_tt_cores[-1],
+                                       remainder)
+
+        else:
+          new_tt_cores[-1] = tf.einsum('oaib,obd->oaid', new_tt_cores[-1],
+                                       remainder)
+        remainder = None
+      # TODO: infer the output ranks and shape.
+      if do_collapse_batch_dim:
+        return TensorTrain(new_tt_cores)
+      else:
+        return TensorTrainBatch(new_tt_cores)
+
+
+def _are_batch_tt_cores_valid(tt_cores, shape, tt_ranks, batch_size):
+  """Check if dimensions of the TT-cores are consistent and the dtypes coincide.
+
+  Args:
+    tt_cores: a tuple of `Tensor` objects
+    shape: An np.array, a tf.TensorShape (for tensors), a tuple of
+      tf.TensorShapes (for TT-matrices or tensors), or None
+    tt_ranks: An np.array or a tf.TensorShape of length len(tt_cores)+1.
+    batch_size: a number or None
+
+  Returns:
+    boolean, True if the dimensions and dtypes are consistent.
+  """
+  shape = shapes.clean_raw_shape(shape)
+  num_dims = len(tt_cores)
+
+  for core_idx in range(1, num_dims):
+    if tt_cores[core_idx].dtype != tt_cores[0].dtype:
+      return False
+  try:
+    for core_idx in range(num_dims):
+      curr_core_shape = tt_cores[core_idx].get_shape()
+      if len(curr_core_shape) != len(tt_cores[0].get_shape()):
+        # Shapes are inconsistent.
+        return False
+      if batch_size is not None and curr_core_shape[0].value is not None:
+        if curr_core_shape[0].value != batch_size:
+          # The TT-cores are not aligned with the given batch_size.
+          return False
+      if shape is not None:
+        for i in range(len(shape)):
+          if curr_core_shape[i + 2] != shape[i][core_idx]:
+            # The TT-cores are not aligned with the given shape.
+            return False
+      if core_idx >= 1:
+        prev_core_shape = tt_cores[core_idx - 1].get_shape()
+        if curr_core_shape[1] != prev_core_shape[-1]:
+          # TT-ranks are inconsistent.
+          return False
+      if tt_ranks is not None:
+        if curr_core_shape[1] != tt_ranks[core_idx]:
+          # The TT-ranks are not aligned with the TT-cores shape.
+          return False
+        if curr_core_shape[-1] != tt_ranks[core_idx + 1]:
+          # The TT-ranks are not aligned with the TT-cores shape.
+          return False
+    if tt_cores[0].get_shape()[1] != 1 or tt_cores[-1].get_shape()[-1] != 1:
+      # The first or the last rank is not 1.
+      return False
+  except ValueError:
+    # The shape of the TT-cores is undetermined, can not validate it.
+    pass
+  return True
+
+
+def _infer_batch_raw_shape(tt_cores):
+  """Tries to infer the (static) raw shape from the TT-cores."""
+  num_dims = len(tt_cores)
+  num_tensor_shapes = len(tt_cores[0].get_shape().as_list()) - 3
+  raw_shape = [[] for _ in range(num_tensor_shapes)]
+  for dim in range(num_dims):
+    curr_core_shape = tt_cores[dim].get_shape()
+    for i in range(num_tensor_shapes):
+      raw_shape[i].append(curr_core_shape[i + 2])
+  for i in range(num_tensor_shapes):
+    raw_shape[i] = tf.TensorShape(raw_shape[i])
+  return tuple(raw_shape)
+
+
+def _infer_batch_tt_ranks(tt_cores):
+  """Tries to infer the (static) raw shape from the TT-cores."""
+  tt_ranks = []
+  for i in range(len(tt_cores)):
+    tt_ranks.append(tt_cores[i].get_shape()[1])
+  tt_ranks.append(tt_cores[-1].get_shape()[-1])
+  return tf.TensorShape(tt_ranks)

--- a/t3f/tensor_train_batch.py
+++ b/t3f/tensor_train_batch.py
@@ -127,6 +127,97 @@ class TensorTrainBatch(TensorTrainBase):
       return "A %d element batch of %s of shape %s, TT-ranks: %s" % \
              (self.batch_size, type_str, shape, tt_ranks)
 
+  def _batch_dim_getitem(self, element_spec):
+    """__getitem__ when provided only one (batch) index.
+
+    Examples:
+      a[1]
+      a[1:3]
+    """
+
+    # This object index is specified exactly and we want to collapse the
+    # batch_size axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
+    do_collapse_batch_dim = isinstance(element_spec, numbers.Number)
+    if not isinstance(element_spec, slice) and not do_collapse_batch_dim:
+      raise ValueError('Expected just 1 index, got %s' % element_spec)
+
+    new_tt_cores = []
+    for core_idx in range(self.ndims()):
+      curr_core = self.tt_cores[core_idx]
+      if self.is_tt_matrix():
+        new_tt_cores.append(curr_core[element_spec, :, :, :, :])
+      else:
+        new_tt_cores.append(curr_core[element_spec, :, :, :])
+    if do_collapse_batch_dim:
+      # This index is specified exactly and we want to collapse the batch_size
+      # axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
+      return TensorTrain(new_tt_cores, self.get_raw_shape(),
+                         self.get_tt_ranks())
+    else:
+      batch_size = new_tt_cores[0].get_shape()[0].value
+      return TensorTrainBatch(new_tt_cores, self.get_raw_shape(),
+                              self.get_tt_ranks(), batch_size)
+
+  def _full_getitem(self, slice_spec):
+    """__getitem__ when provided full index of length ndims + 1.
+
+    Examples:
+      a = t3f.random_tensor_batch((2, 3, 4), batch_size=5)
+      a[:3, 1:2, 4, :]
+    """
+    if len(slice_spec) != self.ndims() + 1:
+      raise ValueError('Expected %d indices, got %d' % (self.ndims() + 1,
+                                                        len(slice_spec)))
+    # This object index is specified exactly and we want to collapse the
+    # batch_size axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
+    do_collapse_batch_dim = isinstance(slice_spec[0], numbers.Number)
+    remainder = None
+    new_tt_cores = []
+    for core_idx in range(self.ndims()):
+      curr_core = self.tt_cores[core_idx]
+      if self.is_tt_matrix():
+        raise NotImplementedError
+      else:
+        sliced_core = curr_core[slice_spec[0], :, slice_spec[core_idx + 1], :]
+        do_collapse_curr_dim = isinstance(slice_spec[core_idx + 1],
+                                          numbers.Number)
+        if do_collapse_curr_dim:
+          # This index is specified exactly and we want to collapse this axis.
+          if remainder is None:
+            remainder = sliced_core
+          else:
+            if do_collapse_batch_dim:
+              remainder = tf.einsum('ab,bd->ad', remainder, sliced_core)
+            else:
+              remainder = tf.einsum('oab,obd->oad', remainder, sliced_core)
+        else:
+          if remainder is not None:
+            # Add reminder from the previous collapsed cores to the current
+            # core.
+            if do_collapse_batch_dim:
+              sliced_core = tf.einsum('ab,bid->aid', remainder, sliced_core)
+            else:
+              sliced_core = tf.einsum('oab,obid->oaid', remainder,
+                                      sliced_core)
+            remainder = None
+          new_tt_cores.append(sliced_core)
+
+    if remainder is not None:
+      # The reminder obtained from collapsing the last cores.
+      if do_collapse_batch_dim:
+        new_tt_cores[-1] = tf.einsum('aib,bd->aid', new_tt_cores[-1],
+                                     remainder)
+
+      else:
+        new_tt_cores[-1] = tf.einsum('oaib,obd->oaid', new_tt_cores[-1],
+                                     remainder)
+      remainder = None
+    # TODO: infer the output ranks and shape.
+    if do_collapse_batch_dim:
+      return TensorTrain(new_tt_cores)
+    else:
+      return TensorTrainBatch(new_tt_cores)
+
   def __getitem__(self, slice_spec):
     """Basic indexing, returns a `TensorTrainBatch` with the specified region.
 
@@ -144,82 +235,24 @@ class TensorTrainBatch(TensorTrainBase):
       is a 2D TensorTrainBatch 2 x 4 with batch_size = 2.
       >>> a[1, :, 1, :]
       is a 2D TensorTrain 2 x 4.
+
+    Returns:
+      `TensorTrainBatch` or `TensorTrain` depending on whether the first
+      (batch) dim was specified as a range or as a number.
     """
     new_tt_cores = []
     slice_only_batch_dim = isinstance(slice_spec, slice) or \
                            isinstance(slice_spec, numbers.Number)
-    first_slice_spec = slice_spec if slice_only_batch_dim else slice_spec[0]
-    # This object index is specified exactly and we want to collapse the
-    # batch_size axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
-    do_collapse_batch_dim = isinstance(first_slice_spec, numbers.Number)
 
     if slice_only_batch_dim:
       # Indexing only for the batch_size axis, e.g. a[1:3].
-      for core_idx in range(self.ndims()):
-        curr_core = self.tt_cores[core_idx]
-        if self.is_tt_matrix():
-          new_tt_cores.append(curr_core[first_slice_spec, :, :, :, :])
-        else:
-          new_tt_cores.append(curr_core[first_slice_spec, :, :, :])
-      if do_collapse_batch_dim:
-        # This index is specified exactly and we want to collapse the batch_size
-        # axis, i.e. return a TensorTrain instead of a TensorTrainBatch.
-        return TensorTrain(new_tt_cores, self.get_raw_shape(),
-                           self.get_tt_ranks())
-      else:
-        batch_size = new_tt_cores[0].get_shape()[0].value
-        return TensorTrainBatch(new_tt_cores, self.get_raw_shape(),
-                                self.get_tt_ranks(), batch_size)
+      return self._batch_dim_getitem(slice_spec)
     elif len(slice_spec) == self.ndims() + 1:
-      remainder = None
-      for core_idx in range(self.ndims()):
-        curr_core = self.tt_cores[core_idx]
-        if self.is_tt_matrix():
-          raise NotImplementedError
-        else:
-          sliced_core = curr_core[slice_spec[0], :, slice_spec[core_idx + 1], :]
-          do_collapse_curr_dim = isinstance(slice_spec[core_idx + 1],
-                                            numbers.Number)
-          if do_collapse_curr_dim:
-            # This index is specified exactly and we want to collapse this axis.
-            if remainder is None:
-              remainder = sliced_core
-            else:
-              if do_collapse_batch_dim:
-                remainder = tf.einsum('ab,bd->ad', remainder, sliced_core)
-              else:
-                remainder = tf.einsum('oab,obd->oad', remainder, sliced_core)
-          else:
-            if remainder is not None:
-              # Add reminder from the previous collapsed cores to the current
-              # core.
-              if do_collapse_batch_dim:
-                sliced_core = tf.einsum('ab,bid->aid', remainder, sliced_core)
-              else:
-                sliced_core = tf.einsum('oab,obid->oaid', remainder,
-                                        sliced_core)
-              remainder = None
-            new_tt_cores.append(sliced_core)
-
-      if remainder is not None:
-        # The reminder obtained from collapsing the last cores.
-        if do_collapse_batch_dim:
-          new_tt_cores[-1] = tf.einsum('aib,bd->aid', new_tt_cores[-1],
-                                       remainder)
-
-        else:
-          new_tt_cores[-1] = tf.einsum('oaib,obd->oaid', new_tt_cores[-1],
-                                       remainder)
-        remainder = None
-      # TODO: infer the output ranks and shape.
-      if do_collapse_batch_dim:
-        return TensorTrain(new_tt_cores)
-      else:
-        return TensorTrainBatch(new_tt_cores)
+      return self._full_getitem(slice_spec)
     else:
       raise ValueError('TensorTrainBatch.__getitem__: wrong number of '
-                       'dimensions, expected %d, got %d' % (self.ndims() + 1,
-                                                            len(slice_spec)))
+                       'dimensions, expected 1 or %d, got %d' %
+                       (self.ndims() + 1, len(slice_spec)))
 
 
 def _are_batch_tt_cores_valid(tt_cores, shape, tt_ranks, batch_size):

--- a/t3f/tensor_train_batch_test.py
+++ b/t3f/tensor_train_batch_test.py
@@ -1,0 +1,139 @@
+import tensorflow as tf
+
+from tensor_train import TensorTrain
+import tensor_train_batch
+import initializers
+import ops
+
+
+class TensorTrainBatchTest(tf.test.TestCase):
+
+  # def testValidateTTCores2d(self):
+  #   schedule = (((1, 1, 1, 1), (1, 1, 1), True),
+  #               ((1, 1, 1, 1), None, True),
+  #               ((1, 1, 1, 1), (1, 2, 1), False),
+  #               ((1, 1, 1, 1), (2, 1, 1), False),
+  #               ((1, 2, 2, 1), (1, 2, 1), True),
+  #               ((1, 2, 2, 1), (1, 1, 1), False),
+  #               ((1, 2, 2, 1), (1, 1, 2), False),
+  #               ((1, 2, 2, 1), None, True),
+  #               ((2, 1, 1, 1), None, False),
+  #               ((2, 1, 1, 1), (1, 1, 1), False),
+  #               ((1, 1, 1, 2), None, False),
+  #               ((1, 1, 1, 2), (1, 1, 1), False),
+  #               ((1, 1, 2, 1), None, False),
+  #               ((1, 1, 2, 1), (1, 2, 1), False),
+  #               ((1, 2, 1, 1), None, False),
+  #               ((1, 2, 1, 1), (1, 2, 1), False))
+  #
+  #   for tt_ranks, claimed_tt_ranks, desired in schedule:
+  #     a = tf.random_normal((tt_ranks[0], 10, tt_ranks[1]))
+  #     b = tf.random_normal((tt_ranks[2], 9, tt_ranks[3]))
+  #     with self.test_session():
+  #       actual = tensor_train._are_tt_cores_valid((a, b), (10, 9),
+  #                                                 claimed_tt_ranks)
+  #       self.assertEqual(desired, actual)
+  #       # Wrong shape.
+  #       actual = tensor_train._are_tt_cores_valid((a, b), (9, 9),
+  #                                                 claimed_tt_ranks)
+  #       self.assertEqual(False, actual)
+  #       if not desired:
+  #         with self.assertRaises(ValueError):
+  #           tensor_train.TensorTrain((a, b), (10, 9), claimed_tt_ranks)
+  #
+  #       # Make dtypes inconsistent.
+  #       b_new = tf.cast(b, tf.float64)
+  #       actual = tensor_train._are_tt_cores_valid((a, b_new), (10, 9),
+  #                                                 claimed_tt_ranks)
+  #       self.assertEqual(False, actual)
+  #       with self.assertRaises(ValueError):
+  #         tensor_train.TensorTrain((a, b_new), (10, 9), claimed_tt_ranks)
+  #
+  # def testValidateTTCores3d(self):
+  #   schedule = (((1, 1, 1, 1, 1, 1), (1, 1, 1, 1), True),
+  #               ((1, 1, 1, 1, 1, 1), None, True),
+  #               ((1, 1, 1, 1, 1, 1), (1, 1, 1, 2), False),
+  #               ((1, 1, 1, 1, 1, 1), (1, 1, 2, 1), False),
+  #               ((1, 2, 2, 2, 2, 1), (1, 2, 2, 1), True),
+  #               ((1, 2, 2, 2, 2, 1), None, True),
+  #               ((1, 2, 2, 2, 2, 1), (1, 2, 1, 1), False),
+  #               ((2, 1, 1, 1, 1, 1), None, False),
+  #               ((2, 1, 1, 1, 1, 1), (2, 1, 1, 1), False),
+  #               ((1, 1, 1, 1, 1, 2), None, False),
+  #               ((1, 1, 1, 1, 1, 2), (1, 1, 1, 2), False),
+  #               ((1, 1, 2, 1, 1, 1), None, False),
+  #               ((1, 1, 2, 1, 1, 1), (1, 2, 1, 1), False),
+  #               ((1, 2, 1, 1, 1, 1), None, False),
+  #               ((1, 2, 1, 1, 1, 1), (1, 2, 1, 1), False),
+  #               ((1, 2, 2, 1, 1, 1), (1, 2, 1, 1), True),
+  #               ((1, 2, 2, 1, 1, 1), (1, 2, 2, 1), False),
+  #               ((1, 2, 2, 1, 1, 1), None, True),
+  #               ((1, 2, 2, 3, 3, 1), (1, 2, 3, 1), True),
+  #               ((1, 2, 2, 3, 3, 1), None, True))
+  #
+  #   for tt_ranks, claimed_tt_ranks, desired in schedule:
+  #     a = tf.random_normal((tt_ranks[0], 10, tt_ranks[1]))
+  #     b = tf.random_normal((tt_ranks[2], 1, tt_ranks[3]))
+  #     c = tf.random_normal((tt_ranks[4], 2, tt_ranks[5]))
+  #     with self.test_session():
+  #       actual = tensor_train._are_tt_cores_valid((a, b, c), (10, 1, 2),
+  #                                                 claimed_tt_ranks)
+  #       self.assertEqual(desired, actual)
+  #       # Wrong shape.
+  #       actual = tensor_train._are_tt_cores_valid((a, b, c), (10, 1, 1),
+  #                                                 claimed_tt_ranks)
+  #       self.assertEqual(False, actual)
+  #       if not desired:
+  #         with self.assertRaises(ValueError):
+  #           tensor_train.TensorTrain((a, b, c), (10, 1, 2), claimed_tt_ranks)
+  #
+  #       # Make dtypes inconsistent.
+  #       b_new = tf.cast(b, tf.float64)
+  #       actual = tensor_train._are_tt_cores_valid((a, b_new, c), (10, 1, 2),
+  #                                                 claimed_tt_ranks)
+  #       self.assertEqual(False, actual)
+  #       with self.assertRaises(ValueError):
+  #         tensor_train.TensorTrain((a, b_new, c), (10, 1, 2), claimed_tt_ranks)
+
+  def testTensorIndexing(self):
+    tens = initializers.random_tensor_batch((3, 3, 4), batch_size=3)
+    with self.test_session() as sess:
+      desired = ops.full(tens)[:, :, :, :]
+      actual = ops.full(tens[:, :, :, :])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+      desired = ops.full(tens)[1:3, :, :, :]
+      actual = ops.full(tens[1:3])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+      desired = ops.full(tens)[1, :, :, :]
+      actual = ops.full(tens[1])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+      desired = ops.full(tens)[2, 1, :, :]
+      actual = ops.full(tens[2, 1, :, :])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+      desired = ops.full(tens)[2, 1:2, 1, :]
+      actual = ops.full(tens[2, 1:2, 1, :])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+      desired = ops.full(tens)[1:2, 0:3, :, 3]
+      actual = ops.full(tens[1:2, 0:3, :, 3])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+      desired = ops.full(tens)[:, 1, :, 3]
+      actual = ops.full(tens[:, 1, :, 3])
+      desired, actual = sess.run([desired, actual])
+      self.assertAllClose(desired, actual)
+
+  # def testTensorIndexingOneElement(self):
+  #   tens = initializers.random_tensor((4, 4, 4))
+  #   with self.test_session() as sess:
+  #     desired = ops.full(tens)[1, 2, 3]
+  #     actual = ops.full(tens[1, 2, 3])
+  #     desired, actual = sess.run([desired, actual])
+  #     self.assertAllClose(desired, actual)
+
+if __name__ == "__main__":
+  tf.test.main()

--- a/t3f/tensor_train_batch_test.py
+++ b/t3f/tensor_train_batch_test.py
@@ -8,93 +8,6 @@ import ops
 
 class TensorTrainBatchTest(tf.test.TestCase):
 
-  # def testValidateTTCores2d(self):
-  #   schedule = (((1, 1, 1, 1), (1, 1, 1), True),
-  #               ((1, 1, 1, 1), None, True),
-  #               ((1, 1, 1, 1), (1, 2, 1), False),
-  #               ((1, 1, 1, 1), (2, 1, 1), False),
-  #               ((1, 2, 2, 1), (1, 2, 1), True),
-  #               ((1, 2, 2, 1), (1, 1, 1), False),
-  #               ((1, 2, 2, 1), (1, 1, 2), False),
-  #               ((1, 2, 2, 1), None, True),
-  #               ((2, 1, 1, 1), None, False),
-  #               ((2, 1, 1, 1), (1, 1, 1), False),
-  #               ((1, 1, 1, 2), None, False),
-  #               ((1, 1, 1, 2), (1, 1, 1), False),
-  #               ((1, 1, 2, 1), None, False),
-  #               ((1, 1, 2, 1), (1, 2, 1), False),
-  #               ((1, 2, 1, 1), None, False),
-  #               ((1, 2, 1, 1), (1, 2, 1), False))
-  #
-  #   for tt_ranks, claimed_tt_ranks, desired in schedule:
-  #     a = tf.random_normal((tt_ranks[0], 10, tt_ranks[1]))
-  #     b = tf.random_normal((tt_ranks[2], 9, tt_ranks[3]))
-  #     with self.test_session():
-  #       actual = tensor_train._are_tt_cores_valid((a, b), (10, 9),
-  #                                                 claimed_tt_ranks)
-  #       self.assertEqual(desired, actual)
-  #       # Wrong shape.
-  #       actual = tensor_train._are_tt_cores_valid((a, b), (9, 9),
-  #                                                 claimed_tt_ranks)
-  #       self.assertEqual(False, actual)
-  #       if not desired:
-  #         with self.assertRaises(ValueError):
-  #           tensor_train.TensorTrain((a, b), (10, 9), claimed_tt_ranks)
-  #
-  #       # Make dtypes inconsistent.
-  #       b_new = tf.cast(b, tf.float64)
-  #       actual = tensor_train._are_tt_cores_valid((a, b_new), (10, 9),
-  #                                                 claimed_tt_ranks)
-  #       self.assertEqual(False, actual)
-  #       with self.assertRaises(ValueError):
-  #         tensor_train.TensorTrain((a, b_new), (10, 9), claimed_tt_ranks)
-  #
-  # def testValidateTTCores3d(self):
-  #   schedule = (((1, 1, 1, 1, 1, 1), (1, 1, 1, 1), True),
-  #               ((1, 1, 1, 1, 1, 1), None, True),
-  #               ((1, 1, 1, 1, 1, 1), (1, 1, 1, 2), False),
-  #               ((1, 1, 1, 1, 1, 1), (1, 1, 2, 1), False),
-  #               ((1, 2, 2, 2, 2, 1), (1, 2, 2, 1), True),
-  #               ((1, 2, 2, 2, 2, 1), None, True),
-  #               ((1, 2, 2, 2, 2, 1), (1, 2, 1, 1), False),
-  #               ((2, 1, 1, 1, 1, 1), None, False),
-  #               ((2, 1, 1, 1, 1, 1), (2, 1, 1, 1), False),
-  #               ((1, 1, 1, 1, 1, 2), None, False),
-  #               ((1, 1, 1, 1, 1, 2), (1, 1, 1, 2), False),
-  #               ((1, 1, 2, 1, 1, 1), None, False),
-  #               ((1, 1, 2, 1, 1, 1), (1, 2, 1, 1), False),
-  #               ((1, 2, 1, 1, 1, 1), None, False),
-  #               ((1, 2, 1, 1, 1, 1), (1, 2, 1, 1), False),
-  #               ((1, 2, 2, 1, 1, 1), (1, 2, 1, 1), True),
-  #               ((1, 2, 2, 1, 1, 1), (1, 2, 2, 1), False),
-  #               ((1, 2, 2, 1, 1, 1), None, True),
-  #               ((1, 2, 2, 3, 3, 1), (1, 2, 3, 1), True),
-  #               ((1, 2, 2, 3, 3, 1), None, True))
-  #
-  #   for tt_ranks, claimed_tt_ranks, desired in schedule:
-  #     a = tf.random_normal((tt_ranks[0], 10, tt_ranks[1]))
-  #     b = tf.random_normal((tt_ranks[2], 1, tt_ranks[3]))
-  #     c = tf.random_normal((tt_ranks[4], 2, tt_ranks[5]))
-  #     with self.test_session():
-  #       actual = tensor_train._are_tt_cores_valid((a, b, c), (10, 1, 2),
-  #                                                 claimed_tt_ranks)
-  #       self.assertEqual(desired, actual)
-  #       # Wrong shape.
-  #       actual = tensor_train._are_tt_cores_valid((a, b, c), (10, 1, 1),
-  #                                                 claimed_tt_ranks)
-  #       self.assertEqual(False, actual)
-  #       if not desired:
-  #         with self.assertRaises(ValueError):
-  #           tensor_train.TensorTrain((a, b, c), (10, 1, 2), claimed_tt_ranks)
-  #
-  #       # Make dtypes inconsistent.
-  #       b_new = tf.cast(b, tf.float64)
-  #       actual = tensor_train._are_tt_cores_valid((a, b_new, c), (10, 1, 2),
-  #                                                 claimed_tt_ranks)
-  #       self.assertEqual(False, actual)
-  #       with self.assertRaises(ValueError):
-  #         tensor_train.TensorTrain((a, b_new, c), (10, 1, 2), claimed_tt_ranks)
-
   def testTensorIndexing(self):
     tens = initializers.random_tensor_batch((3, 3, 4), batch_size=3)
     with self.test_session() as sess:
@@ -126,14 +39,6 @@ class TensorTrainBatchTest(tf.test.TestCase):
       actual = ops.full(tens[:, 1, :, 3])
       desired, actual = sess.run([desired, actual])
       self.assertAllClose(desired, actual)
-
-  # def testTensorIndexingOneElement(self):
-  #   tens = initializers.random_tensor((4, 4, 4))
-  #   with self.test_session() as sess:
-  #     desired = ops.full(tens)[1, 2, 3]
-  #     actual = ops.full(tens[1, 2, 3])
-  #     desired, actual = sess.run([desired, actual])
-  #     self.assertAllClose(desired, actual)
 
 if __name__ == "__main__":
   tf.test.main()

--- a/t3f/tensor_train_test.py
+++ b/t3f/tensor_train_test.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tensorflow as tf
 
 import tensor_train


### PR DESCRIPTION
Start implementing the batch TT interface.

Added a new class TensorTrainBatch.
Now functions like add, multiply, matmul, flat_inner accept:
add(TTBatch, TT) -- add TT to each element of TTBatch
add(TTBatch, TTBatch) -- add two batches elementwise

Functions like frobenious_norm returns a tensor of numbers for a TTBatch (norm of each element in the batch).

Functions like round do rounding on each element.

Created new functions zeros_batch, ones_batch, random_tensor_batch, random_matrix_batch which accept batch_size as an input (default is batch_size=1).

Created function to_tt_tensor_batch(a) where the first dimension of a is treated like batch dimension and the rest is treated like tensor.