### PR TITLE
gather

### DIFF
--- a/t3f/__init__.py
+++ b/t3f/__init__.py
@@ -15,6 +15,7 @@ from t3f.ops import matmul
 from t3f.ops import multiply
 from t3f.ops import quadratic_form
 from t3f.ops import transpose
+from t3f.ops import gather_batch_dim
 from t3f.ops import gather_nd
 
 from t3f.batch_ops import concat_along_batch_dim

--- a/t3f/ops.py
+++ b/t3f/ops.py
@@ -1080,6 +1080,17 @@ def cast(tt_a, dtype):
                      'TensorTrainBatch.' % tt_a)
 
 
+def gather_batch_dim(tt_batch, indices):
+  """out[i] = tt_batch[indices[i]]
+  
+  """
+  new_tt_cores = []
+  for core in tt_batch.tt_cores:
+    new_tt_cores.append(tf.gather(core, indices))
+  return TensorTrainBatch(new_tt_cores, tt_batch.get_raw_shape(),
+                          tt_batch.get_tt_ranks(), tt_batch.batch_size())
+
+
 def gather_nd(tt, indices):
   """out[i] = tt[indices[i, 0], indices[i, 1], ...]
 


### PR DESCRIPTION
gather along one axis (like tt[:, :, :, idx, :, :] but without specifying many ':' and with support for tensor indexing: t3f.gather(tt, t3f.placeholder(tf.int32, 10), axis=3) and along batch dim