### PR TITLE
Fix documentation build problem

### DIFF
--- a/docs/tf_requirement.txt
+++ b/docs/tf_requirement.txt
@@ -4,4 +4,4 @@
 # the docs with readthedocs.org: they fetch a fresh version of the
 # library on each build and it doesn't import properly without tensorflow
 # being installed.
-tensorflow>=1.0
+tensorflow>=1.0,<=1.5


### PR DESCRIPTION
Readthedocs recently failed to build the documentation with "Illegal instruction (core dumped)". The problem seems to be with the newer versions of TF (https://github.com/tensorflow/tensorflow/issues/17411), so I restricted the version used for documentation build to TF 1.5