### PR TITLE
tf.mul -> tf.multiply

### DIFF
--- a/t3f/regularizers.py
+++ b/t3f/regularizers.py
@@ -34,7 +34,7 @@ def l2_regularizer(scale, scope=None):
       my_scale = tf.convert_to_tensor(scale,
                                        dtype=tt.dtype.base_dtype,
                                        name='scale')
-      return tf.mul(my_scale, ops.frobenius_norm_squared(tt), name=name)
+      return tf.multiply(my_scale, ops.frobenius_norm_squared(tt), name=name)
 
   return l2
 
@@ -74,6 +74,6 @@ def cores_regularizer(core_regularizer, scale, scope=None):
       penalty = 0.0
       for i in range(tt.ndims()):
         penalty += core_regularizer(tt.tt_cores[i])
-      return tf.mul(my_scale, penalty, name=name)
+      return tf.multiply(my_scale, penalty, name=name)
 
   return regularizer


### PR DESCRIPTION
A small fix--it seems `tf.mul` was replaced with `tf.multiply` in versions 1.0.0+ of TF