### PR TITLE
Added tests for checking composite ranks

### DIFF
--- a/t3f/decompositions.py
+++ b/t3f/decompositions.py
@@ -138,7 +138,7 @@ def to_tt_tensor(tens, max_tt_rank=10, epsilon=None):
   # Raises ValueError if ndims is not defined.
   d = static_shape.__len__()
   max_tt_rank = np.array(max_tt_rank).astype(np.int32)
-  if max_tt_rank < 1:
+  if np.any(max_tt_rank < 1):
     raise ValueError('Maximum TT-rank should be greater or equal to 1.')
   if epsilon is not None and epsilon < 0:
     raise ValueError('Epsilon should be non-negative.')

--- a/t3f/decompositions_test.py
+++ b/t3f/decompositions_test.py
@@ -62,42 +62,32 @@ class DecompositionsTest(tf.test.TestCase):
     with self.test_session():
       self.assertAllClose(vec, ops.full(tt_vec).eval())
 
- 
-  def testTTCompositeRank(self):
-    # Test if a composite rank (list of ranks) can be used for decomposition
-    np_tensor = np.random.rand(2,3,3,1)
-    tf_tensor = tf.constant(np_tensor)
-
-    tt_ranks = [1,2,3,3,1]
-    tt_tensor = decompositions.to_tt_tensor(tf_tensor, max_tt_rank = tt_ranks)
-    with self.test_session():
-      self.assertAllClose(np_tensor, ops.full(tt_tensor).eval())
-
   def testTTCompositeRankTensor(self):
-    # Test if a composite rank (list of ranks) can be used for decomposition for tensor
+    # Test if a composite rank (list of ranks) can be used for decomposition
+    # for tensor.
     np.random.seed(1)
-    np_tensor = np.random.rand(2,3,3,1)
+    np_tensor = np.random.rand(2, 3, 3, 1)
     tf_tensor = tf.constant(np_tensor)
 
-    tt_ranks = [1,2,3,3,1]
-    tt_tensor = decompositions.to_tt_tensor(tf_tensor, max_tt_rank = tt_ranks)
+    tt_ranks = [1, 2, 3, 3, 1]
+    tt_tensor = decompositions.to_tt_tensor(tf_tensor, max_tt_rank=tt_ranks)
     with self.test_session():
       self.assertAllClose(np_tensor, ops.full(tt_tensor).eval())
 
   def testTTCompositeRankMatrix(self):
-    # Test if a composite rank (list of ranks) can be used for decomposition for a matrix
+    # Test if a composite rank (list of ranks) can be used for decomposition
+    # for a matrix.
     inp_shape = (2, 3, 3, 2)
     out_shape = (1, 2, 2, 1)
     np.random.seed(1)
     mat = np.random.rand(np.prod(out_shape), np.prod(inp_shape))
     mat = mat.astype(np.float32)
     tf_mat = tf.constant(mat)
-    tt_ranks = [10,20,30,40,30]
+    tt_ranks = [10, 20, 30, 40, 30]
     tt_mat = decompositions.to_tt_matrix(tf_mat, (out_shape, inp_shape),
                                          max_tt_rank=tt_ranks)
     with self.test_session():
       self.assertAllClose(mat, ops.full(tt_mat).eval(), atol=1e-5, rtol=1e-5)
-
       
   def testTTMatrix(self):
     # Convert a np.prod(out_shape) x np.prod(in_shape) matrix into TT-matrix
@@ -108,7 +98,8 @@ class DecompositionsTest(tf.test.TestCase):
     mat = np.random.rand(np.prod(out_shape), np.prod(inp_shape))
     mat = mat.astype(np.float32)
     tf_mat = tf.constant(mat)
-    tt_mat = decompositions.to_tt_matrix(tf_mat, (out_shape, inp_shape), max_tt_rank=90)
+    tt_mat = decompositions.to_tt_matrix(tf_mat, (out_shape, inp_shape),
+                                         max_tt_rank=90)
     with self.test_session():
       # TODO: why so bad accuracy?
       self.assertAllClose(mat, ops.full(tt_mat).eval(), atol=1e-5, rtol=1e-5)

--- a/t3f/decompositions_test.py
+++ b/t3f/decompositions_test.py
@@ -62,6 +62,43 @@ class DecompositionsTest(tf.test.TestCase):
     with self.test_session():
       self.assertAllClose(vec, ops.full(tt_vec).eval())
 
+ 
+  def testTTCompositeRank(self):
+    # Test if a composite rank (list of ranks) can be used for decomposition
+    np_tensor = np.random.rand(2,3,3,1)
+    tf_tensor = tf.constant(np_tensor)
+
+    tt_ranks = [1,2,3,3,1]
+    tt_tensor = decompositions.to_tt_tensor(tf_tensor, max_tt_rank = tt_ranks)
+    with self.test_session():
+      self.assertAllClose(np_tensor, ops.full(tt_tensor).eval())
+
+  def testTTCompositeRankTensor(self):
+    # Test if a composite rank (list of ranks) can be used for decomposition for tensor
+    np.random.seed(1)
+    np_tensor = np.random.rand(2,3,3,1)
+    tf_tensor = tf.constant(np_tensor)
+
+    tt_ranks = [1,2,3,3,1]
+    tt_tensor = decompositions.to_tt_tensor(tf_tensor, max_tt_rank = tt_ranks)
+    with self.test_session():
+      self.assertAllClose(np_tensor, ops.full(tt_tensor).eval())
+
+  def testTTCompositeRankMatrix(self):
+    # Test if a composite rank (list of ranks) can be used for decomposition for a matrix
+    inp_shape = (2, 3, 3, 2)
+    out_shape = (1, 2, 2, 1)
+    np.random.seed(1)
+    mat = np.random.rand(np.prod(out_shape), np.prod(inp_shape))
+    mat = mat.astype(np.float32)
+    tf_mat = tf.constant(mat)
+    tt_ranks = [10,20,30,40,30]
+    tt_mat = decompositions.to_tt_matrix(tf_mat, (out_shape, inp_shape),
+                                         max_tt_rank=tt_ranks)
+    with self.test_session():
+      self.assertAllClose(mat, ops.full(tt_mat).eval(), atol=1e-5, rtol=1e-5)
+
+      
   def testTTMatrix(self):
     # Convert a np.prod(out_shape) x np.prod(in_shape) matrix into TT-matrix
     # and back.
@@ -71,8 +108,7 @@ class DecompositionsTest(tf.test.TestCase):
     mat = np.random.rand(np.prod(out_shape), np.prod(inp_shape))
     mat = mat.astype(np.float32)
     tf_mat = tf.constant(mat)
-    tt_mat = decompositions.to_tt_matrix(tf_mat, (out_shape, inp_shape),
-                                         max_tt_rank=90)
+    tt_mat = decompositions.to_tt_matrix(tf_mat, (out_shape, inp_shape), max_tt_rank=90)
     with self.test_session():
       # TODO: why so bad accuracy?
       self.assertAllClose(mat, ops.full(tt_mat).eval(), atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
Did you find a reason for poor reconstruction error despite setting max_tt_ranks to a high number? This was put as a To-Do under "testTTMatrix" in t3f/decompositions_test.py (line 77 before commit)